### PR TITLE
Hex generation from RGB without colormap

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,5 +1,4 @@
 import requests
-from colormap import rgb2hex
 import os
 from tkinter import messagebox
 
@@ -21,8 +20,7 @@ def generate_code(token,link,path_to_save):
         el_r = element["fills"][0]["color"]['r'] * 255
         el_g = element["fills"][0]["color"]['g'] * 255
         el_b = element["fills"][0]["color"]['b'] * 255
-        hex_code = rgb2hex(round(el_r), round(el_g), round(el_b))
-        return hex_code
+        return ('#%02x%02x%02x' % (round(el_r), round(el_g), round(el_b)))
 
 
     def get_coordinates(element):


### PR DESCRIPTION
Hex generation can be done without colormap. Hence saves us to import a module.