### PR TITLE
Add support for Tkinter "Text" object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
+__pycache__/
+.DS_Store
 .idea/Figma2Py.iml
 .idea/inspectionProfiles/profiles_settings.xml
 .idea/modules.xml
 .idea/vcs.xml
-__pycache__/window.cpython-39.pyc
-.DS_Store
 .idea/misc.xml
 .idea/workspace.xml
-__pycache__/backend.cpython-39.pyc
+.vscode
 env

--- a/backend.py
+++ b/backend.py
@@ -129,7 +129,12 @@ def generate_code(token,link,path_to_save):
             text = text.replace("\n", "\\n")
             lines.extend([f'canvas.create_text({x},{y},text="{text}",fill="{color}",font=("{font}",int({fontSize})))\n'])
 
-        elif element["name"] == 'TextBox':
+        elif element["name"] in ('TextBox', 'TextArea'):
+            element_types = {
+                "TextArea": "Text",
+                "TextBox": "Entry"
+            }
+
             width, height = get_dimensions(element)
             x, y = get_coordinates(element)
             x, y = x + (width / 2), y + (height / 2)
@@ -159,7 +164,7 @@ def generate_code(token,link,path_to_save):
             x, y = get_coordinates(element)
             x = x + corner_radius
 
-            lines.extend([f'entry{text_entry_count} = Entry(bd=0,bg="{bg}",highlightthickness=0)',
+            lines.extend([f'entry{text_entry_count} = {element_types[element["name"]]}(bd=0,bg="{bg}",highlightthickness=0)',
                           f'entry{text_entry_count}.place(x={x},y={y},width={reduced_width},height={reduced_height})\n'])
 
             text_entry_count += 1

--- a/instructions.md
+++ b/instructions.md
@@ -81,6 +81,7 @@ ___
 | --- | --- |
 | Button | Button |
 | Rectangle | Rectangle |
+| TextArea | Text |
 | TextBox | Entry |
 | Background | Canvas.Image() |
 
@@ -103,19 +104,24 @@ ___
    * If you use multiple shapes/images, you must group them together by selecting them all and pressing <kbd>CTRL/&#8984; + G</kbd>
 <br><br>
 
-3. **Text**
+3. **Text (Literal)**
    * Use the <kbd>T</kbd> key to activate the text tool, then add text as desired
    * Text does not have to be renamed for use in Tkinter Designer
    * Explicitly press the <kbd>Return</kbd>  Or  <kbd>Enter</kbd> Key to move to the next line.
 <br><br>
 
-4. **Entry**
+4. **Entry (Single-Line User Input)**
    * Activate the Rectangle tool with <kbd>R</kbd>
    * Adjust the Rectangle to your liking
    * Make sure the Rectangle is named "TextBox"
 <br><br>
 
-5. **Rectangle**
+5. **Text (Multi-Line User Input)**
+   * Activate the Rectangle tool with <kbd>R</kbd>
+   * Adjust the Rectangle to your liking
+   * Make sure the Rectangle is named "TextArea"
+
+6. **Rectangle**
    * Activate the Rectangle tool with <kbd>R</kbd>
    * Adjust the Rectangle to your liking
    * Make sure the Rectangle is named "Rectangle"


### PR DESCRIPTION
Currently, Tkinter Designer only supports the `Entry` element for user-input, but it was really easy to implement the `Text` input element built into Tkinter. This element allows the user to input multi-line text.

Because the implementation was so similar to that of the `Entry`, I simply added a test against `element["name"]` that creates the appropriate element (`TextBox` or `TextArea`, named after the similar element in HTML). I'm not sure if this could create any issues compatibility-wise, so this may need some further review before being merged.