### PR TITLE
Add translations section to each markdown document

### DIFF
--- a/docs/instructions.fr-FR.md
+++ b/docs/instructions.fr-FR.md
@@ -1,5 +1,12 @@
 # Comment utiliser Tkinter Designer
 
+#### Traductions:
+- [简体中文](/docs/instructions.zh-CN.md)
+- [English](/docs/instructions.md)
+- [Français](/docs/instructions.fr-FR.md)
+
+___
+
 ## Sommaire:
 1. [**Commencer**](#commencer-haut)
    1. [Installer Python](#getting-started-1)

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,5 +1,12 @@
 # How to use Tkinter Designer
 
+#### Translations:
+- [简体中文](/docs/instructions.zh-CN.md)
+- [English](/docs/instructions.md)
+- [Français](/docs/instructions.fr-FR.md)
+
+___
+
 ## Table of Contents:
 1. [**Getting Started**](#getting-started-top)
    1. [Install Python](#getting-started-1)

--- a/docs/instructions.zh-CN.md
+++ b/docs/instructions.zh-CN.md
@@ -1,5 +1,12 @@
 # 如何使用 Tkinter Designer
 
+#### 翻译:
+- [简体中文](/docs/instructions.zh-CN.md)
+- [English](/docs/instructions.md)
+- [Français](/docs/instructions.fr-FR.md)
+
+___
+
 ## 目录:
 1. [**入门**](#入门-top)
    1. [安装Python](#getting-started-1)

--- a/docs/readme.fr-FR.md
+++ b/docs/readme.fr-FR.md
@@ -13,6 +13,13 @@
 
   <br>
 
+#### Traductions:
+- [简体中文](/docs/readme.zh-CN.md)
+- [English](/readme.md)
+- [Français](/docs/readme.fr-FR.md)
+
+___ 
+
 ## 💡 Introduction
 
 Tkinter Designer a été créé pour accélérer le processus de développement des interfaces en Python. Il utilise le logiciel de design bien connu [Figma](https://www.figma.com/) afin de rendre la création de magnifiques interfaces Tkinter en Python du gâteau 🍰.

--- a/docs/readme.zh-CN.md
+++ b/docs/readme.zh-CN.md
@@ -14,6 +14,13 @@
 
   <br>
 
+#### 翻译:
+- [简体中文](/docs/readme.zh-CN.md)
+- [English](/readme.md)
+- [Français](/docs/readme.fr-FR.md)
+
+___ 
+
 ## 💡 介绍
 
 Tkinter Designer 旨在加速 Python 中的 GUI 开发过程。 它使用著名的设计软件 [Figma](https://www.figma.com/) 使在 Python 中创建漂亮的 Tkinter GUI 变得轻而易举。
@@ -75,10 +82,10 @@ Tkinter Designer 的可能性是无限的，但这里有几个可以在 Tkinter 
 
 <small>以下不是我的创作。</small>
 
-### Registration Page
+### 注册页面
 <img width="467" alt="Example 1" src="https://user-images.githubusercontent.com/42001064/119250338-1f1adf80-bbbd-11eb-8ee1-72028a4e7a7f.png">
 
-### Branding Page
+### 品牌页面
 <img width="467" alt="Example 2" src="https://user-images.githubusercontent.com/42001064/119250668-496d9c80-bbbf-11eb-886b-cb1e75da18df.png">
 
 ### Frame Recorder [(More Info)](https://github.com/mehmet-mert/FrameRecorder)

--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,14 @@
 
   <br>
 
+#### Translations:
+- [简体中文](/docs/readme.zh-CN.md)
+- [English](/readme.md)
+- [Français](/docs/readme.fr-FR.md)
+
+___ 
+
 ## 💡 Introduction
-
-Read this in - [(简体中文)](/docs/readme.zh-CN.md) [(Français)](/docs/readme.fr-FR.md)
-
 Tkinter Designer was created to speed up the GUI development process in Python. It uses the well-known design software [Figma](https://www.figma.com/) to make creating beautiful Tkinter GUIs in Python a piece of cake 🍰.
 
 Tkinter Designer uses the Figma API to analyse a design file and create the respective code and files needed for the GUI. Even Tkinter Designer's GUI is created using Tkinter Designer.


### PR DESCRIPTION
Linked up translated README and instructions documents.

Also changed "Registration Page" and "Branding Page" in [Chinese README](https://github.com/ParthJadhav/Tkinter-Designer/blob/master/docs/readme.zh-CN.md) to something *probably* closer to their direct translation. I simply plugged both into Google Translate, but changed the word "Branding" to "Brand" to *possibly* prevent some confusion between branding for a company and branding for a horse.