### PR TITLE
update link of instructions on app

### DIFF
--- a/tkinter_designer.py
+++ b/tkinter_designer.py
@@ -38,7 +38,7 @@ def select_path(event):
     # window.deiconify()
 
 def know_more_clicked(event):
-    url = "https://github.com/ParthJadhav/Tkinter-Designer/blob/master/instructions.md"
+    url = "https://github.com/ParthJadhav/Tkinter-Designer/blob/master/docs/instructions.md"
     webbrowser.open_new(url)
 
 def make_label(master, x, y, h, w, *args, **kwargs):


### PR DESCRIPTION


When I clicked on the `Click here for instructions.` on the app, it returned [this link](https://github.com/ParthJadhav/Tkinter-Designer/blob/master/instructions.md) which is a 404 upon landing on the page.

![Screen Shot 2021-07-09 at 9 44 30 PM](https://user-images.githubusercontent.com/45283313/125087824-6888a500-e0ff-11eb-95da-c3d583f67359.png)