### PR TITLE
Added fix for aligning Text elements

### DIFF
--- a/tkdesigner/figma/custom_elements.py
+++ b/tkdesigner/figma/custom_elements.py
@@ -74,6 +74,7 @@ class Text(Vector):
 canvas.create_text(
     {self.x},
     {self.y},
+    anchor="nw",
     text="{self.text}",
     fill="{self.text_color}",
     font=("{self.font}", int({self.font_size}))


### PR DESCRIPTION
When adding a Text element to a Canvas, Tkinter defaults to center alignment (the property _anchor_ defaults to "CENTER" if not specified) and also ignores the Figma bounding box size, instead determining the pixel size of the Text element from the text content and font size. This causes aligment problems in the generated output. Adding:

`    anchor="nw"`

makes the alignment better.

Note: alignment in this case is not related to the Text Align property in Figma. It's purely how Tkinter positions a Text element.

More info on Tkinter Text 'anchor' property here:

https://www.tutorialspoint.com/python/tk_anchors.htm
