### PR TITLE
Fixed font scaling and wrong font issues

### DIFF
--- a/tkdesigner/figma/custom_elements.py
+++ b/tkdesigner/figma/custom_elements.py
@@ -65,6 +65,7 @@ class Text(Vector):
     def font_property(self):
         style = self.node.get("style")
         font_name = style["fontPostScriptName"]
+        font_name = font_name.replace('-', ' ')
         font_size = style["fontSize"]
         return font_name, font_size
 

--- a/tkdesigner/figma/custom_elements.py
+++ b/tkdesigner/figma/custom_elements.py
@@ -68,7 +68,6 @@ class Text(Vector):
         font_size = style["fontSize"]
         return font_name, font_size
 
-    # This Change can be ignored.
     def to_code(self):
         return f"""
 canvas.create_text(
@@ -77,7 +76,7 @@ canvas.create_text(
     anchor="nw",
     text="{self.text}",
     fill="{self.text_color}",
-    font=("{self.font}", int({self.font_size}))
+    font=("{self.font}", -1 * {int(self.font_size)})
 )
 """
 

--- a/tkdesigner/template.py
+++ b/tkdesigner/template.py
@@ -3,7 +3,6 @@ TEMPLATE = """
 # https://github.com/ParthJadhav/Tkinter-Designer
 
 
-import os
 from pathlib import Path
 
 from tkinter import *


### PR DESCRIPTION
- Changed code from using points for font size to pixels to fix the scaling issue.

Turns out the way Figma handles font names is a bit tricky.
It doesn't store font style name on its own, but instead stores it in combination with the font family name in `fontPostScriptName` attribute. This requires one to parse out the style name from full font name.
This PR uses a simple method tested on Windows, Mac and Linux operating systems to solve that issue.
The issue will persist if the font is not installed on the system or if the font name doesn't match the one installed.