### PR TITLE
Added translation of Figma Text alignment to Tkinter 'anchor' property

### DIFF
--- a/tkdesigner/figma/custom_elements.py
+++ b/tkdesigner/figma/custom_elements.py
@@ -80,7 +80,6 @@ class Text(Vector):
 
         font_name = font_name.replace('-', ' ')
         font_size = style["fontSize"]
-        print(font_name, font_size)
         return font_name, font_size
 
     def to_code(self):

--- a/tkdesigner/figma/custom_elements.py
+++ b/tkdesigner/figma/custom_elements.py
@@ -36,13 +36,12 @@ button_{self.id_}.place(
 class Text(Vector):
     def __init__(self, node, frame):
         super().__init__(node)
-
         self.x, self.y = self.position(frame)
         self.width, self.height = self.size()
-
         self.text_color = self.color()
         self.font, self.font_size = self.font_property()
         self.text = self.characters.replace("\n", "\\n")
+        self.anchor = self.alignment()
 
     @property
     def characters(self) -> str:
@@ -81,6 +80,7 @@ class Text(Vector):
 
         font_name = font_name.replace('-', ' ')
         font_size = style["fontSize"]
+        print(font_name, font_size)
         return font_name, font_size
 
     def to_code(self):
@@ -88,7 +88,7 @@ class Text(Vector):
 canvas.create_text(
     {self.x},
     {self.y},
-    anchor="nw",
+    anchor={self.anchor},
     text="{self.text}",
     fill="{self.text_color}",
     font=("{self.font}", {int(self.font_size)} * -1),

--- a/tkdesigner/figma/vector_elements.py
+++ b/tkdesigner/figma/vector_elements.py
@@ -34,6 +34,25 @@ class Vector(Node):
         y = abs(y - frame_y)
         return x, y
 
+    # Returns a two-letter string as a parameter for the 'anchor' property of
+    # a Tkinter Text widget. The string is a combination of the Figma properties
+    # textAlignHorizontal and textAlingVertical
+    def alignment(self):
+        align_translate = {
+            "LEFT-TOP": "NW",
+            "CENTER-TOP": "N",
+            "RIGHT-TOP": "NE",
+            "LEFT-CENTER": "W",
+            "CENTER-CENTER": "CENTER",
+            "RIGHT-CENTER": "E",
+            "LEFT-BOTTOM": "SW",
+            "CENTER-BOTTOM": "S",
+            "RIGHT-BOTTOM": "SE"
+        }
+        halign = self.style["textAlignHorizontal"]
+        valign = self.style["textAlignVertical"]
+        return(align_translate[f"{halign}-{valign}"])
+
 
 class Star(Vector):
     def __init__(self, node):


### PR DESCRIPTION
Figma uses LEFT, RIGHT, TOP, BOTTOM, CENTER for text alignment within a text frame whereas Tkinter uses N, S, E, W and CENTER.

This update adds some translation of the Figma 'textAlignHorizontal' and 'textAlignVertical' properites to Tkinter's 'anchor' property.

Note: this does not address the issue of the difference in parent 'object' that the alignment relates to. In Figma the alignment is relative to the Text Frame. Tkinter does not have a Text Frame widget and any Figma text is translated into a Text wdiget whoose aligment (the 'anchor' property) is relative to the Canvas itself.

As a consequence the only really reliable aligment settings in Figma is TOP and LEFT. This is default so should work most of the time but if the user has selected different alignment in Figma it will not translate correctly to Tkdesigner output.

This is an interim commit as coming up with a solution to this needs more thought and consideration than I have time for right now though I will come back to it in a couple of weeks.
