### PR TITLE
Fixed path not found in exe format (Fatal error)

### DIFF
--- a/tkdesigner/template.py
+++ b/tkdesigner/template.py
@@ -8,14 +8,10 @@ from pathlib import Path
 # from tkinter import *
 # Explicit imports to satisfy Flake8
 from tkinter import Tk, Canvas, Entry, Text, Button, PhotoImage
-
-
-OUTPUT_PATH = Path(__file__).parent
-ASSETS_PATH = OUTPUT_PATH / Path("{{ assets_path }}")
-
+from os import getcwd
 
 def relative_to_assets(path: str) -> Path:
-    return ASSETS_PATH / Path(path)
+    return f'{getcwd()}\\assets\\{path}'
 
 
 window = Tk()


### PR DESCRIPTION
Changing the way of using paths, makes it flexible specially when when a user want to convert python Tkinter app into exe.
It fixes Fatal error (path not found).