### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ chardet==4.0.0; python_version >= "2.7" and python_version != "3.0.*" and python
 idna==2.10; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*"
 jinja2==3.0.1; python_version >= "3.6"
 markupsafe==2.0.1; python_version >= "3.6"
-pillow==8.4.0; python_version >= "3.6"
+pillow==9.4.0; python_version >= "3.6"
 requests==2.25.1; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*" and python_version != "3.4.*"
 urllib3==1.26.6; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*" and python_version != "3.4.*" and python_version < "4"


### PR DESCRIPTION
Pillow 8.4.0 isn't compatible with Python 3.11 which makes the package uninstallable.