### PR TITLE
FIXED ALL THE ISSUES!! Updated!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 certifi==2021.5.30
-chardet==4.0.0; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*" and python_version != "3.4.*"
-idna==2.10; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*"
-jinja2==3.0.1; python_version >= "3.6"
-markupsafe==2.0.1; python_version >= "3.6"
-pillow==9.4.0; python_version >= "3.6"
-requests==2.25.1; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*" and python_version != "3.4.*"
-urllib3==1.26.6; python_version >= "2.7" and python_version != "3.0.*" and python_version != "3.1.*" and python_version != "3.2.*" and python_version != "3.3.*" and python_version != "3.4.*" and python_version < "4"
+chardet==4.0.0
+idna==2.10
+jinja2==3.0.1
+markupsafe==2.0.1
+Pillow >= 10.1
+requests==2.25.1
+urllib3==1.26.6

--- a/tkdesigner/utils.py
+++ b/tkdesigner/utils.py
@@ -20,6 +20,6 @@ def download_image(url, image_path):
     response = requests.get(url)
     content = io.BytesIO(response.content)
     im = Image.open(content)
-    im = im.resize((im.size[0] // 2, im.size[1] // 2), Image.ANTIALIAS)
+    im = im.resize((im.size[0] // 2, im.size[1] // 2), Image.LANCZOS)
     with open(image_path, "wb") as file:
         im.save(file)


### PR DESCRIPTION
Added some changes, now **Tkinter-Designer** works for latest **python 3.12.1**.

Fixes: #347 #358 #366 #369 #377 #383 

1. Updated the pillow package version in requirements.txt that works for python 3.12 (Pillow >= 10.1)
2. Updated the utils.py accordingly that has latest pillow module. (LANCZOS)

Hi Parth, I request you to merge my PR.

Thanks!