### PR TITLE
Update instructions.fr-FR.md

### DIFF
--- a/docs/instructions.fr-FR.md
+++ b/docs/instructions.fr-FR.md
@@ -236,7 +236,7 @@ python3 gui.py
 
 ```
 cd Tkinter-Designer
-interface graphique cd
+cd gui
 python3 gui.py
 ```
 


### PR DESCRIPTION
fixed a translation mishap in code blocks, 'cd gui' got translated literally while it shouldn't have been