### PR TITLE
fix(deps): update Pillow dependency to >=10.0.0 to fix pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 python = "^3.8"
 requests = "2.25.1"
 Jinja2 = "3.0.1"
-Pillow = "^8.4.0"
+Pillow = ">= 10.0.0"
 urllib3 = "^1.26.6"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Solved issue #465 

Bug: PyPI release still pins Pillow <9.0.0, causing install failure on Python 3.10+
When installing tkdesigner from PyPI (pip install tkdesigner), the package forces Pillow<9.0.0.
This installs Pillow 8.4.0, which fails to build on modern Python versions (3.10+) and macOS with the following error:

metadata-generation-failed
× Encountered error while generating package metadata.
note: This is an issue with the package mentioned above, not pip.

Observed behavior
Fails with metadata-generation-failed when building Pillow 8.4.0.

Expected behavior
tkdesigner should install successfully with a modern version of Pillow (>=10.0.0)

This PR fixes installation issues on modern Python environments.

- After merging, a new PyPI release will be needed to propagate the fix.

Cause

-      requirements.txt in the repo already specifies Pillow >= 10.1 ✅
- 	But pyproject.toml still pins Pillow = "^8.4.0" ❌
- 	The PyPI release (1.0.7) was built using the outdated pyproject.toml.

Proposed Fix

- Update pyproject.toml to match requirements.txt:
   Pillow = ">=10.1"